### PR TITLE
Absolute path for mounted volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,6 @@ RUN nginx -t
 
 COPY init.sh /
 EXPOSE 80
-VOLUME ["app/db","app/packagefiles"]
+VOLUME ["/app/db","/app/packagefiles"]
 CMD ["sh", "init.sh"]
 


### PR DESCRIPTION
Relative mounted volume path create unamable volumes in docker compose or swarm mode.